### PR TITLE
feat(scheduler): Add main binary for generating or extending schedule

### DIFF
--- a/actions/generate-schedule/main.go
+++ b/actions/generate-schedule/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/ghodss/yaml"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spinnaker/rotation-scheduler/actions/generate-schedule/scheduler"
+	"github.com/spinnaker/rotation-scheduler/actions/generate-schedule/users"
+	"github.com/spinnaker/rotation-scheduler/proto/schedule"
+)
+
+var (
+	// Required flags
+	stop              = flag.String("stop", "", "Stop generating the schedule after this date. Date is exclusive (not included in the schedule), and must be in the format 2006-01-02.")
+	shiftDurationDays = flag.Int("shiftDurationDays", 7, "The duration of each shift in days")
+	// TODO(ttomsu): Flag is required now, make optional later (once GH teams integration works).
+	userList = flag.String("users", "", "Comma-separated list of users in the rotation. Usernames will be alphabetically sorted prior to assigning shifts.")
+
+	start                = flag.String("start", "", "Start generating from this date. If this flag and previousSchedule are not specified, starts from tomorrow's date.")
+	previousSchedulePath = flag.String("previousSchedule", "", "Path to a previous schedule's YAML file.")
+
+	outFilepath = flag.String("out", "", "File to write out new schedule. Will overwrite the file if it exists. If not specified, writes to stdout.")
+)
+
+const (
+	startStopFormat = "2006-01-02"
+	usersSeparator  = ","
+)
+
+func main() {
+	flag.Parse()
+
+	if err := validateFlags(); err != nil {
+		log.Fatalf("Error validating flags: %v", err)
+	}
+
+	userSlice := strings.Split(*userList, usersSeparator)
+	userSource := users.NewStaticSource(userSlice...)
+
+	sched, err := scheduler.NewScheduler(userSource, *shiftDurationDays)
+	if err != nil {
+		log.Fatalf("Error creating scheduler: %v", err)
+	}
+
+	stopTime, _ := time.Parse(startStopFormat, *stop)
+
+	var newSchedule *schedule.Schedule
+	if *previousSchedulePath != "" {
+		previousSchedule, err := parsePreviousSchedule(*previousSchedulePath)
+		if err != nil {
+			log.Fatalf("Error parsing previous schedule: %v", err)
+		}
+
+		err = sched.ExtendSchedule(previousSchedule, stopTime)
+		if err != nil {
+			log.Fatalf("Error extending schedule: %v", err)
+		}
+	} else {
+		var startTime time.Time
+		if *start != "" {
+			startTime, _ = time.Parse(startStopFormat, *start)
+		} else {
+			startTime = time.Now().AddDate(0, 0, 1) // tomorrow.
+		}
+
+		newSchedule, err = sched.Schedule(startTime, stopTime)
+		if err != nil {
+			log.Fatalf("Error generating new schedule: %v", err)
+		}
+	}
+
+	scheduleBytes, err := yaml.Marshal(newSchedule)
+	if err != nil {
+		log.Fatalf("Error marshalling schedule to yaml: %v", err)
+	}
+
+	destFilepath := os.Stdout.Name()
+	if *outFilepath != "" {
+		destFilepath = *outFilepath
+	}
+	if err := ioutil.WriteFile(destFilepath, scheduleBytes, 0644); err != nil {
+		log.Fatalf("Error writing out new schedule: %v", err)
+	}
+}
+
+func validateFlags() error {
+	if *stop == "" {
+		return fmt.Errorf("--stop flag missing")
+	} else if _, err := time.Parse(startStopFormat, *stop); err != nil {
+		return fmt.Errorf("error parsing --stop value. Must be in the format %v: %v", startStopFormat, err)
+	}
+
+	if *shiftDurationDays <= 0 {
+		return fmt.Errorf("--shiftDuration must be a positive integer")
+	}
+
+	if *previousSchedulePath != "" {
+		if info, err := os.Stat(*previousSchedulePath); os.IsNotExist(err) {
+			return fmt.Errorf("previousSchedule file (%v) not found: %v", *previousSchedulePath, err)
+		} else if info.IsDir() {
+			return fmt.Errorf("previousSchedule must be a file, got a directory")
+		}
+	} else if *start != "" {
+		if _, err := time.Parse(startStopFormat, *start); err != nil {
+			return fmt.Errorf("error parsing --start value. Must be in the format %v: %v", startStopFormat, err)
+		}
+	}
+
+	if *userList == "" {
+		return fmt.Errorf("--users must be specified")
+	}
+
+	return nil
+}
+
+func parsePreviousSchedule(previousSchedulePath string) (*schedule.Schedule, error) {
+	prevBytes, err := ioutil.ReadFile(previousSchedulePath)
+	if err != nil {
+		return nil, err
+	}
+
+	prevSched := &schedule.Schedule{}
+	if err := yaml.Unmarshal(prevBytes, prevSched); err != nil {
+		return nil, err
+	}
+	return prevSched, nil
+}

--- a/actions/generate-schedule/main.go
+++ b/actions/generate-schedule/main.go
@@ -84,7 +84,7 @@ func main() {
 	if *outFilepath != "" {
 		destFilepath = *outFilepath
 	}
-	if err := ioutil.WriteFile(destFilepath, scheduleBytes, 0644); err != nil {
+	if err := ioutil.WriteFile(destFilepath, scheduleBytes, 0666); err != nil {
 		log.Fatalf("Error writing out new schedule: %v", err)
 	}
 }


### PR DESCRIPTION
Please review only the last commit - the first two are covered in https://github.com/spinnaker/rotation-scheduler/pull/1

Sample invocations:

```
$ go run actions/generate-schedule/main.go \
  --stop 2020-03-25 \
  --shiftDurationDays 1 \
  --users ttomsu,plumpy \
  --out ./foobar.yaml
```

Yields:

```
shifts:
- startDate: Wed 18 Mar 2020
  user: plumpy
- startDate: Thu 19 Mar 2020
  user: ttomsu
- startDate: Fri 20 Mar 2020
  user: plumpy
- startDate: Sat 21 Mar 2020
  user: ttomsu
- startDate: Sun 22 Mar 2020
  user: plumpy
- startDate: Mon 23 Mar 2020
  user: ttomsu
- startDate: Tue 24 Mar 2020
  user: plumpy
```

And then extending it with:

```
$ go run actions/generate-schedule/main.go \
  --stop 2020-04-01 \
  --shiftDurationDays 1 \
  --users ttomsu,plumpy,duftler \
  --previousSchedule ./foobar.yaml \
  --out ./foobar.yaml
```

```
shifts:
- startDate: Wed 18 Mar 2020
  user: plumpy
- startDate: Thu 19 Mar 2020
  user: ttomsu
- startDate: Fri 20 Mar 2020
  user: plumpy
- startDate: Sat 21 Mar 2020
  user: ttomsu
- startDate: Sun 22 Mar 2020
  user: plumpy
- startDate: Mon 23 Mar 2020
  user: ttomsu
- startDate: Tue 24 Mar 2020
  user: plumpy
- startDate: Wed 25 Mar 2020
  user: ttomsu
- startDate: Thu 26 Mar 2020
  user: duftler
- startDate: Fri 27 Mar 2020
  user: plumpy
- startDate: Sat 28 Mar 2020
  user: ttomsu
- startDate: Sun 29 Mar 2020
  user: duftler
- startDate: Mon 30 Mar 2020
  user: plumpy
- startDate: Tue 31 Mar 2020
  user: ttomsu
```
