### PR TITLE
feat(container): Run a.) in a docker container, and then b.) in a GHAction

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,18 @@ jobs:
       run: go build ./...
     - name: Test
       run: go test ./...
+
+  dockerBuild:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - id: dates
+      run: |
+        echo "::set-output name=today::$(date '+%Y-%m-%d')"&& \
+        echo "::set-output name=day30::$(date '+%Y-%m-%d' -d '+30 days')"
+    - name: schedule generate
+      uses: ./
+      with:
+        args: |
+          schedule generate --start ${{ steps.dates.outputs.today }} --stop ${{ steps.dates.outputs.day30 }} --users abc,lmn,xyz samples/schedule.yaml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,3 +19,18 @@ jobs:
       run: go build ./...
     - name: Test
       run: go test ./...
+
+  dockerBuild:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - id: dates
+      run: |
+        echo "::set-output name=today::$(date '+%Y-%m-%d')"&& \
+        echo "::set-output name=day30::$(date '+%Y-%m-%d' -d '+30 days')"
+    - name: schedule generate
+      uses: ./
+      with:
+        args: |
+          schedule generate --start ${{ steps.dates.outputs.today }} --stop ${{ steps.dates.outputs.day30 }} --users abc,lmn,xyz samples/schedule.yaml

--- a/.github/workflows/testAction.yml
+++ b/.github/workflows/testAction.yml
@@ -1,0 +1,35 @@
+on: [push]
+
+jobs:
+  test:
+    # Can be used by a developer in a fork to confirm this GHA is working as expected.
+    if: "!startsWith(github.repository, 'spinnaker/')"
+    runs-on: ubuntu-latest
+    name: Test Action Use
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - id: dates
+      run: |
+        echo "::set-output name=today::$(date '+%Y-%m-%d')"&& \
+        echo "::set-output name=day30::$(date '+%Y-%m-%d' -d '+30 days')" && \
+        echo "::set-output name=day60::$(date '+%Y-%m-%d' -d '+60 days')"
+
+    - name: schedule generate
+      uses: ./
+      with:
+        args: |
+          schedule generate --start ${{ steps.dates.outputs.today }} --stop ${{ steps.dates.outputs.day30 }} --users abc,lmn,xyz samples/schedule.yaml
+
+    - name: schedule extend
+      uses: ./
+      with:
+        args: |
+          schedule extend --stop ${{ steps.dates.outputs.day60 }} --users abc,lmn,xyz --schedule samples/schedule.yaml samples/schedule.yaml
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v2
+      with:
+        commit-message: |
+          chore(build-cop): Update build cop rotation schedule

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.14-alpine as builder
+
+ADD . /workspace
+WORKDIR /workspace
+
+ENV GOPROXY=https://proxy.golang.org
+ENV GOPATH="/go"
+
+# 'go install' puts the rotation binary in /go/bin/
+RUN go env && go install -ldflags="-s -w" rotation.go
+
+# -------
+
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /go/bin/rotation /usr/local/bin/rotation
+
+ENTRYPOINT ["rotation"]

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,6 @@
+name: Rotation Tool
+description: A tool to generate and extend rotation schedules, then sync them with Google Calendar.
+
+runs:
+  using: docker
+  image: Dockerfile

--- a/cmd/extend.go
+++ b/cmd/extend.go
@@ -13,10 +13,10 @@ import (
 
 var (
 	extendCmd = &cobra.Command{
-		Use:              "extend [outputFile]",
-		Short:            "Extends a previously generated schedule",
-		TraverseChildren: true,
-		RunE:             executeExtend,
+		Use:   "extend [outputFile]",
+		Short: "Extends a previously generated schedule",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  executeExtend,
 	}
 
 	previousSchedulePath string

--- a/rotation.go
+++ b/rotation.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spinnaker/rotation-scheduler/cmd"
 )
 
 func main() {
-	_ = cmd.Execute()
+	err := cmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/samples/schedule.yaml
+++ b/samples/schedule.yaml
@@ -1,0 +1,10 @@
+shifts:
+- startDate: Fri 03 Apr 2020
+  user: abc
+- startDate: Fri 10 Apr 2020
+  user: lmn
+- startDate: Fri 17 Apr 2020
+  user: xyz
+- startDate: Fri 24 Apr 2020
+  stopDate: Thu 30 Apr 2020
+  user: abc


### PR DESCRIPTION
This PR proves out a way to use use the rotation scheduler as GH Action step. It adds a check to its own CI process to build the Dockerfile and confirm basic usage (a smoke test if you will).

There is also a `testAction` workflow that I was using as a sample of how the `spinnaker/spinnaker` project workflow might look like (as in step 1.) extend the schedule X days, then 2.) create a PR with the extension. Not shown is the step that `rotation calendar syncs` it)