### PR TITLE
feat(prune): Adds --prune flag to remove old shifts and reschedule an…

### DIFF
--- a/.github/workflows/testAction.yml
+++ b/.github/workflows/testAction.yml
@@ -12,7 +12,7 @@ jobs:
 
     - id: dates
       run: |
-        echo "::set-output name=today::$(date '+%Y-%m-%d')"&& \
+        echo "::set-output name=day-30::$(date '+%Y-%m-%d' -d '-30 days')"&& \
         echo "::set-output name=day30::$(date '+%Y-%m-%d' -d '+30 days')" && \
         echo "::set-output name=day60::$(date '+%Y-%m-%d' -d '+60 days')"
 
@@ -20,13 +20,19 @@ jobs:
       uses: ./
       with:
         args: |
-          schedule generate --start ${{ steps.dates.outputs.today }} --stop ${{ steps.dates.outputs.day30 }} --users abc,lmn,xyz samples/schedule.yaml
+          schedule generate --start ${{ steps.dates.outputs.day-30 }} --stop ${{ steps.dates.outputs.day30 }} --users abc,lmn,xyz samples/schedule.yaml
 
-    - name: schedule extend
+    - name: cat before
+      run: cat samples/schedule.yaml
+
+    - name: schedule prune and extend
       uses: ./
       with:
         args: |
-          schedule extend --stop ${{ steps.dates.outputs.day60 }} --users abc,lmn,xyz --schedule samples/schedule.yaml samples/schedule.yaml
+          schedule extend --stop ${{ steps.dates.outputs.day60 }} --prune --users abc,xyz --schedule samples/schedule.yaml samples/schedule.yaml
+
+    - name: cat after
+      run: cat samples/schedule.yaml
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v2

--- a/cmd/extend.go
+++ b/cmd/extend.go
@@ -20,12 +20,16 @@ var (
 	}
 
 	previousSchedulePath string
+
+	prune bool
 )
 
 func init() {
 	extendCmd.Flags().StringVarP(&previousSchedulePath, "schedule", "s", "", "Required. Filepath to the schedule to extend.")
 	_ = extendCmd.MarkFlagRequired("schedule")
 	_ = extendCmd.MarkFlagFilename("schedule", "yaml")
+
+	extendCmd.Flags().BoolVarP(&prune, "prune", "p", false, "Prune removes all shifts before the current shift and reschedules all shifts if shift owners are no longer in rotation.")
 
 	scheduleCmd.AddCommand(extendCmd)
 }
@@ -50,7 +54,7 @@ func executeExtend(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("error creating new scheduler: %v", err)
 	}
 
-	err = schdlr.ExtendSchedule(sched, stopTime)
+	err = schdlr.ExtendSchedule(sched, stopTime, prune)
 	if err != nil {
 		return fmt.Errorf("error generating new schedule: %v", err)
 	}

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -32,7 +32,7 @@ func (sch *Schedule) Validate() error {
 	}
 
 	if sch.LastShift() == nil {
-		return nil
+		return fmt.Errorf("shifts cannot be empty")
 	}
 
 	var previousStartDate time.Time
@@ -85,6 +85,13 @@ type Shift struct {
 	// StopDate is inclusive, and must only be used on the last Shift of a Schedule. For all other Shifts, the stop date
 	// is implied by the next shift's StartDate, and this value should remain the zero `time.Time` value.
 	StopDate time.Time `json:"stopDate,omitempty"`
+}
+
+func (sh *Shift) GetUser() string {
+	if sh.UserOverride != "" {
+		return sh.UserOverride
+	}
+	return sh.User
 }
 
 // StartDateExclusive returns the date before the start date, which is the StopDateInclusive of the previous shift.

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -22,12 +22,14 @@ func TestScheduleValidate(t *testing.T) {
 		{
 			desc:     "empty schedule",
 			schedule: &Schedule{},
+			wantErr:  true,
 		},
 		{
 			desc: "empty shifts",
 			schedule: &Schedule{
 				Shifts: []*Shift{},
 			},
+			wantErr: true,
 		},
 		{
 			desc: "invalid shift",

--- a/users/usersource_test.go
+++ b/users/usersource_test.go
@@ -29,6 +29,13 @@ func TestStartAfter(t *testing.T) {
 		next2      string
 	}{
 		{
+			desc:       "start after missing, single element",
+			users:      []string{"a"},
+			startAfter: "missing",
+			next1:      "a",
+			next2:      "a",
+		},
+		{
 			desc:       "start after a",
 			users:      []string{"a", "b", "c"},
 			startAfter: "a",
@@ -99,5 +106,15 @@ func TestStartAfter(t *testing.T) {
 				t.Errorf("next2: want %v, got %v", tc.next2, got)
 			}
 		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	ss := NewStaticSource("a")
+
+	if !ss.Contains("a") {
+		t.Errorf("should contain a")
+	} else if ss.Contains("b") {
+		t.Errorf("should not contain b")
 	}
 }


### PR DESCRIPTION
…y shifts that contain users no longer in the rotation.

Removing old shifts and users should make this tool ready enough to start testing out on `spinnaker/spinnaker`. 