### PR TITLE
feat(calendar): Use public GitHub email for calendar invites, if available

### DIFF
--- a/cmd/schedule.go
+++ b/cmd/schedule.go
@@ -30,6 +30,8 @@ var (
 
 	userList    []string
 	githubFlags []string
+
+	emailDomains []string
 )
 
 func init() {
@@ -41,6 +43,8 @@ func init() {
 	scheduleCmd.PersistentFlags().StringSliceVarP(&userList, "users", "u", []string{}, "Set of users for the rotation. Required if --github* options are not specified.")
 
 	scheduleCmd.PersistentFlags().StringSliceVarP(&githubFlags, "github", "g", []string{}, "Fetch the user list from GitHub. Order of args must be 'organization,team,accessToken'. Must specify an access token with read:org permissions.")
+
+	scheduleCmd.PersistentFlags().StringSliceVar(&emailDomains, "domains", []string{"*"}, "Only include email addresses from --github that match these domains. A single value of '*' will allow any domain. Use '--domains []' to only use GitHub usernames.")
 
 	rootCmd.AddCommand(scheduleCmd)
 }
@@ -71,7 +75,7 @@ func userSrc() (users.Source, error) {
 			return nil, err
 		}
 		client, closer, err := ghHttpClient(github)
-		userSrc, err = ghteams.NewGitHubTeamsUserSource(client, github.org, github.team)
+		userSrc, err = ghteams.NewGitHubTeamsUserSource(client, github.org, github.team, emailDomains...)
 		if err != nil {
 			return nil, fmt.Errorf("error creating GitHub users source: %v", err)
 		}

--- a/gcal/gcal.go
+++ b/gcal/gcal.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/spinnaker/rotation-scheduler/schedule"
@@ -61,7 +62,7 @@ func (g *GCal) Schedule(sched *schedule.Schedule) error {
 	}
 
 	for i, ie := range internalEvents {
-		_, err := g.svc.Events.Insert(g.CalendarID, ie.GcalEvent).SendUpdates("none").Do()
+		_, err := g.svc.Events.Insert(g.CalendarID, ie.GcalEvent).SendUpdates("externalOnly").Do()
 		if err != nil {
 			return fmt.Errorf("insert error with event at index %v: %v\nEvent value:\n%+v", i, err, ie.GcalEvent)
 		} else {
@@ -103,6 +104,11 @@ func internalEvents(sched *schedule.Schedule) []*internalEvent {
 			End: &calendar.EventDateTime{
 				Date: stopDateExcl.Format(DateFormat), // End.Date is exclusive
 			},
+		}
+		if strings.Contains(u, "@") {
+			event.Attendees = append(event.Attendees, &calendar.EventAttendee{
+				Email: u,
+			})
 		}
 		intEvents[i] = &internalEvent{
 			GcalEvent:    event,

--- a/gcal/gcal_test.go
+++ b/gcal/gcal_test.go
@@ -17,6 +17,9 @@ const (
 	testCalendarID = "spinbot@spinnaker.io"
 )
 
+// schedule.replay file generated with:
+// JSON_KEY=$(cat rotation-scheduler.json | base64 -w 0)
+// go run rotation.go calendar sync --record ./gcal/testing/schedule.replay --jsonKey $JSON_KEY ./gcal/testing/test_schedule.yaml
 func TestSchedule(t *testing.T) {
 	replayer, err := httpreplay.NewReplayer("testing/schedule.replay")
 	if err != nil {

--- a/gcal/testing/schedule.replay
+++ b/gcal/testing/schedule.replay
@@ -29,7 +29,7 @@
   },
   "Entries": [
     {
-      "ID": "3a421c12f524fc4f",
+      "ID": "ba82eb6d8e74352f",
       "Request": {
         "Method": "POST",
         "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/clear?alt=json\u0026prettyPrint=false",
@@ -60,7 +60,7 @@
             "no-cache, no-store, max-age=0, must-revalidate"
           ],
           "Date": [
-            "Tue, 31 Mar 2020 16:41:49 GMT"
+            "Wed, 08 Apr 2020 18:54:47 GMT"
           ],
           "Expires": [
             "Mon, 01 Jan 1990 00:00:00 GMT"
@@ -80,10 +80,10 @@
       }
     },
     {
-      "ID": "d50ec4d3db1f3fea",
+      "ID": "a34ca389867d4e92",
       "Request": {
         "Method": "POST",
-        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=none",
+        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=externalOnly",
         "Header": {
           "Accept-Encoding": [
             "gzip"
@@ -122,10 +122,10 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 31 Mar 2020 16:41:49 GMT"
+            "Wed, 08 Apr 2020 18:54:47 GMT"
           ],
           "Etag": [
-            "\"3171345818964000\""
+            "\"3172744174606000\""
           ],
           "Expires": [
             "Mon, 01 Jan 1990 00:00:00 GMT"
@@ -150,14 +150,14 @@
             "1; mode=block"
           ]
         },
-        "Body": "H4sIAAAAAAAAAJVS2W7bMBD8FYN99UEdcWQBRQInaZCiaIE6R6OmD5S4lhnxUHnYiA3/e5YGnD4UCJDXnRnOzix3pBOak5I0TILmzH6CNWhPhgQ8a3H+RLLkNMnykyIpZtOcUvpEEBVR0+U9NNAlKaPs+VTpbtYKz6GuDTKcZz64+LLRS2EVcByuvJLfhO5wvPK+d+Vkstlsxq0xrYRxY9TkuMfksMcZCP6ZbX9uqofvkm2vXh5v5yv2zH2t3EmVSlpd34tHVbRNNu9r9XXNr+bb5lqGWn2x1a+bwB4KtG0sMA9x5ZSmdESzUZbcJtMyT8p8NsZMFZJCz98h5UUaSS4oxewLkljdDBa90Jp1YAc/FovBPAjJBxemPzoaS8odAcWERIFDcm38uTuKxuLQE8glKb0NsB8SY1umxRY+LMS2rY+imOEtwnREE4IoxBP/jxURExdM3t1cvnvO838HOhj/DaAbfIoOiQWFHwisiwbBwSUsWZC4ypJJB5hoDdYKDoj/3hEFfmVixb3pQ+wJxcFHMKH7P/v9KykAWqSPAgAA"
+        "Body": "H4sIAAAAAAAAAJVS224TMRD9lci85uK9NNmuhKjSBCgi8JAimlAevPZk14m93viSQKP8e8eVAg9IlXidc87MOTNzIjvZClISzhS0gtk3cIDWkz4Bz2qsP5IsmaSTPE8m+ZiOKaWPBFEZNbRQe5dXnG+3TXNI+P5aJONM6lAgw3nmg4udTbuRVoPAYuO1+izbHZYb7ztXjkbH43FYG1MrGHKjRxcfoxcf70CKt4tZ4/jDgq70ly3TnWEfV79W2fxqPZuni1R5cV/XPJt2lf50EPPpE/+gQqXf2/XDXWDfoxdugXmIllOa0gHNB7S4T4ryKi/zyRAzrZEUOvEKKaNZJLmgNbO/kcQq3lt2sm3ZDmzv63LZmwapRO/WdJeJxpLyREAzqVDgkFwZf+MuoqE0sSOoDSm9DXDuE2Nr1son+G8hbtv6KIoZ/kQYD2hCEIV44n+xImLylqlvd7NXz3nz90Avg/cBWo6taJ9Y0PhAYF0cEBzMYMOCQisbphxgogNYKwUg/uNENPjGxBV3pgtxTygOPoIJPf88n58BaYcLKI8CAAA="
       }
     },
     {
-      "ID": "19f84d62facf74af",
+      "ID": "d467a7f4b1cfe912",
       "Request": {
         "Method": "POST",
-        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=none",
+        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=externalOnly",
         "Header": {
           "Accept-Encoding": [
             "gzip"
@@ -196,10 +196,10 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 31 Mar 2020 16:41:50 GMT"
+            "Wed, 08 Apr 2020 18:54:47 GMT"
           ],
           "Etag": [
-            "\"3171345819608000\""
+            "\"3172744175394000\""
           ],
           "Expires": [
             "Mon, 01 Jan 1990 00:00:00 GMT"
@@ -224,14 +224,14 @@
             "1; mode=block"
           ]
         },
-        "Body": "H4sIAAAAAAAAAJVSXW8TMRD8K5F5zYedu6buSYgqDYQiqkgEVBrKg++8uZj4C5+dlET576wrBR6QKvG6M7Ozs7tHslVWkoo0QoOVIryCHdhI+gSiaLH+SAp2yYrygrOrCeWU0keCqMoaaTh3lz62zvhaS/HD6KJ0tuANMrooYupyZ2fXKhiQWNxEoz8qu8XyJkbfVaPRfr8fts61GoaNM6PzHKPnOd6Akq9Xc1ou5rxo3n+y9ZjtH8zT9uHex3p2R+txeVjM79qmmPrafNjJt9NDM9epNu/C6uttEvccbZsAIkIeeUzHdECLQcE+s0lVsqq8GmKmFZKSly+QOC0zqUvGiPALSdrY3tIra8UWQm+xXPamSWnZu3H+7OgCqY4EjFAaBR2Saxevu7NoqFzuCHpNqhgSnPrEhVZYdYD/FuK2Q8yinOFPhMmAcoIo5BP/g7GLjKkbob/czl485/XfAz0b/0xgG2xF+ySAwQeC0GWD1MEM1iJpHGUtdAeYaAchKAmIfzsSA3Hj8oq98ynvCcUpZpDR0/fT6TcNqIMHjwIAAA=="
+        "Body": "H4sIAAAAAAAAAJVSy24aQRD8FTS5YtgnCytFsbCdyFG0KIIIx3EOszu9y8A81vMABcS/p8cS9iGSpVy7qrqruvtEdlwxUpKGClCMmg+wB+XIkICjHdafSBoXSZFlcZGnsyyKoieCKA+aWcEmU1/Q4tlCs61nLJcp5NvWTpFhHXXehs5atdxIYFjcOCm+cbXD8sa53pbj8eFwGHVadwJGjZbji4/xi49PwNnHxYrtqu0mrpK7tHmoxM+k54v197heVaJa97I5dl2Tzvtaft2zu/mx+SJ8LT+bx4d7T9fBS2OAOgiWkyiJrqLsKpqu4mmZZ2VWjDDTI5J8z94hTWZFIFkvJTV/kCSkGix7rhTdgRkslsvB3HPBBje6v0zUhpQnApJygQKL5Fq7a3sRjbgOHUG0pHTGw3lItOmo4kf4byFu27ggChleI0wwAkEUwon/weI8YPyGih/3t++e8/rtQC+Dnz2oBltFQ2JA4gOBsWGAt3ALLfUCrbRUWMBEezCGM0D814lIcBsdVtzr3oc9odi7AMbR+ff5/BdOCcSxjwIAAA=="
       }
     },
     {
-      "ID": "18f40b6e2559b2a4",
+      "ID": "86b1437e72321e34",
       "Request": {
         "Method": "POST",
-        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=none",
+        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=externalOnly",
         "Header": {
           "Accept-Encoding": [
             "gzip"
@@ -270,10 +270,10 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 31 Mar 2020 16:41:50 GMT"
+            "Wed, 08 Apr 2020 18:54:48 GMT"
           ],
           "Etag": [
-            "\"3171345820448000\""
+            "\"3172744176154000\""
           ],
           "Expires": [
             "Mon, 01 Jan 1990 00:00:00 GMT"
@@ -298,14 +298,14 @@
             "1; mode=block"
           ]
         },
-        "Body": "H4sIAAAAAAAAAJVSy27bMBD8FYO9+kG9EkNA0UBxm7po04Mb2HDTA02uZFqkSPNhJTH87yUNODkUCNDrzszOzu4eUcs7hkpEiYCOEfMBDtA5NETgSBPqjyhLrpMsL6YpzvMpxvgRBZRHTbqrYZcWel/46QFTd623Bu85Y21gWEect7Gz6mpuJLBQ3DopvvOuDeWtc9qWk0nf9+NGqUbAmCo5ucwxOc/xCTj7+ENquV6q5/tV9XS/esjZrtqxGevJ13lPl6Jd39mGZpXeyG8H9rl6oXfCb+QXs17NPVlOgy01QBycR8YpHuFslCW/kqsyT8oCj0OmdSB5zd4hpWkeSdZLScxzIJENHSw07zrSghn8XCwGleeCDW6Vvjgqg8ojAkm4CAIbyBvlbuxFNOYqdgRRo9IZD6chUqYhHX+B/xaGbRsXRTHDa4SrUVKggEI88T9YmkaM3xLxMJ+9e86btwOdjfceOhpa4SEyIMMDgbHRwFuYQU28CKPURFgIiQ5gDGcQ8N9HJMFtVVyxVtrHPQWxdxFM8OnP6fQXAKUGc48CAAA="
+        "Body": "H4sIAAAAAAAAAJVSy27bMBD8FYO5+kFRcuQKKBo4TtsEMYLCSZq66YEiVzJtPlQ+bMSG/z1kALeHAgF63ZnZndndA9oIzVGFGJWgObVnsAXtUR+Bp22sP6M8K0lZFFl5no0LjPEziqhImlWgeaNIKcmmDtbYrOBFmRvGJpHhPPXBpc5GN8Iq4LG48kreCr1JYu87V41Gu91u2BrTShgyo0YnH6M3H59A8I/06+NqTpZ+vuZurrzgTzdbtr7Cy9m3fE4+rH/s25bl065WN1t+Nd2zLzLU6rNdPl0H+j15YRaoh2SZYIIHuBjgyX02qcZFVUyGMdMykkLH3yOVZSK5oBS1L5FEa9ZbdEJrugHbu1ssetMgJO9dmu400VhUHRAoKmQUuEiujb9wJ9FQmNQRZIMqbwMc+8jYlmqxh/8Wxm1bn0Qpw58I54NsjCIK6cT/YIQkTFxS+XA9e/ecF38P9Db4dwDNYivcRxZUfCCwLg0IDmbQ0CCjlYZKBzHRFqwVHCL+84AU+JVJK+5MF9Keojj4BGb4+Ot4fAWmfbI/jwIAAA=="
       }
     },
     {
-      "ID": "6facdf30d0c30484",
+      "ID": "9c8bca9a77339c7f",
       "Request": {
         "Method": "POST",
-        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=none",
+        "URL": "https://www.googleapis.com/calendar/v3/calendars/spinbot%40spinnaker.io/events?alt=json\u0026prettyPrint=false\u0026sendUpdates=externalOnly",
         "Header": {
           "Accept-Encoding": [
             "gzip"
@@ -344,10 +344,10 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Tue, 31 Mar 2020 16:41:50 GMT"
+            "Wed, 08 Apr 2020 18:54:48 GMT"
           ],
           "Etag": [
-            "\"3171345821336000\""
+            "\"3172744176986000\""
           ],
           "Expires": [
             "Mon, 01 Jan 1990 00:00:00 GMT"
@@ -372,7 +372,7 @@
             "1; mode=block"
           ]
         },
-        "Body": "H4sIAAAAAAAAAJVS227aQBD9FbR95bJrg3EsRYkIpUrVkgfa0ND0YW0PZuu9uHsBNYh/72wkkodKkfI655w5c2bmSFqha1KQikvQNbcfYA/akz4BzxusP5KUTVk6nuQJS9OMUvpIEBVRk00kqEnbeM5bybQ20wsznob9tEKG89wHFzsbvRVWQY3FnVfyi9Atlnfed64YjQ6Hw7AxppEwrIwanecYPc9xBaK+XP6+d5s1ZTyp6cN6Ycv5IpQqT+/WOV2m98ky+dpU6awr1ed9/XH2VH2SiC/s5sdt4OscbSsL3EMcOaEJHdB0kLJvLCvGrJjQIWbaICl09RukLMsjyQWluP2LJF5WvVUntOYt2N7datWbBSHr3o3pzo7GkuJIQHEhUeCQXBp/7c6ioTCxI8gtKbwNcOoTYxuuxRO8W4jbtj6KYoaXCNkgSQiiEE/8P3YRMXHD5ffb+ZvnvH490LPxnwC6wla0TywofCCwLhoEB3PY8iBxlC2XDjDRHqwVNSD+80gU+J2JK+5MF+KeUBx8BBk9/Tqd/gH86459jwIAAA=="
+        "Body": "H4sIAAAAAAAAAJVSy27bQAz8FWN79UOv2LKAoIGTJk3RpAcncaymh5WWkrfeh7oPGbHhfy83gNtDgQC9cmbIGZIHsuWKkYLUVIBi1HyAHpQjQwKOtlh/IWk8S2ZZFs+m83waRdELQZQHTSrZNK1YfaYpNGBcn8qmp5LTHBnWUedt6KxVw40EhsWNk+IrV1ssb5zrbDGZ7Ha7cat1K2Bcazk5+Zi8+fgInJ3fJfH2/uc9L2/u4iq5FqV8emWf1/tqVSbrVdytH9q2ThddJb/07NNiX98IX8lrUz7feroKXmoD1EGwnERJNIqyUZQ/xHlxlhVZPsZMJZJ8x94hZfM0kKyXkppXJNGqHiw7rhTdghl8Wy4HC88FG1zq7jRRG1IcCEjKBQoskivtLuxJNOY6dATRkMIZD8ch0aaliu/hv4W4beOCKGT4E2E6ShKCKIQT/4vNA8YvqXi8vXr3nBd/D/Q2+JcHVWOraEgMSHwgMDYM8BauoKFeoJWGCguYqAdjOAPEvx+IBLfRYcWd7nzYE4q9C2AcHX8cj78B8v4mlo8CAAA="
       }
     }
   ]

--- a/users/ghteams/ghteams.go
+++ b/users/ghteams/ghteams.go
@@ -3,6 +3,7 @@ package ghteams
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/google/go-github/v30/github"
 	"github.com/spinnaker/rotation-scheduler/users"
@@ -13,18 +14,36 @@ type GitHubTeamsUserSource = users.StaticSource
 // NewGitHubTeamsUserSource fetches the current GitHub usernames from the specified team. The http.Client implementation
 // must attach a GitHub personal access token (with the 'read:org' scope) to the request, such as one from the oauth2
 // package.
-func NewGitHubTeamsUserSource(client *http.Client, orgName, teamName string) (*GitHubTeamsUserSource, error) {
+func NewGitHubTeamsUserSource(client *http.Client, orgName, teamName string, emailDomains ...string) (*GitHubTeamsUserSource, error) {
 	ghClient := github.NewClient(client)
+	ctx := context.Background()
 
-	ghUsers, _, err := ghClient.Teams.ListTeamMembersBySlug(context.Background(), orgName, teamName, nil /*opts*/)
+	ghUsers, _, err := ghClient.Teams.ListTeamMembersBySlug(ctx, orgName, teamName, nil /*opts*/)
 	if err != nil {
 		return nil, err
 	}
 
-	var logins []string
-	for _, ghu := range ghUsers {
-		logins = append(logins, ghu.GetLogin())
+	loginsAndEmails := make([]string, len(ghUsers))
+	for i, ghu := range ghUsers {
+		login := ghu.GetLogin()
+		if len(emailDomains) > 0 {
+			if userDetails, _, err := ghClient.Users.Get(ctx, login); err == nil { // Just use login if an error occurs.
+				if len(emailDomains) == 1 && emailDomains[0] == "*" {
+					if userDetails.GetEmail() != "" {
+						login = userDetails.GetEmail()
+					}
+				} else {
+					for _, d := range emailDomains {
+						if strings.HasSuffix(userDetails.GetEmail(), d) {
+							login = userDetails.GetEmail()
+							break
+						}
+					}
+				}
+			}
+		}
+		loginsAndEmails[i] = login
 	}
 
-	return users.NewStaticSource(logins...), nil
+	return users.NewStaticSource(loginsAndEmails...), nil
 }

--- a/users/ghteams/ghteams_test.go
+++ b/users/ghteams/ghteams_test.go
@@ -8,6 +8,16 @@ import (
 	"cloud.google.com/go/httpreplay"
 )
 
+var (
+	wellKnownDomains = []string{
+		"armory.io",
+		"google.com",
+		"netflix.com",
+	}
+)
+
+// Replay generated from:
+// go run rotation.go schedule generate --record ./users/ghteams/testing/teams.replay --github spinnaker,build-cops,$GITHUB_TOKEN --start 2020-05-01 --stop 2020-06-01 --domains armory.io,netflix.com,google.com
 func TestNewGitHubTeamsUserSource(t *testing.T) {
 	r, err := httpreplay.NewReplayer("testing/teams.replay")
 	if err != nil {
@@ -19,7 +29,7 @@ func TestNewGitHubTeamsUserSource(t *testing.T) {
 		t.Fatalf("error creating replayer client: %v", err)
 	}
 
-	ghUserSrc, err := NewGitHubTeamsUserSource(client, "spinnaker", "build-cops")
+	ghUserSrc, err := NewGitHubTeamsUserSource(client, "spinnaker", "build-cops", wellKnownDomains...)
 	if err != nil {
 		t.Fatalf("error getting users: %v", err)
 	}
@@ -33,14 +43,13 @@ func TestNewGitHubTeamsUserSource(t *testing.T) {
 	want := []string{
 		"ajordens",
 		"cfieber",
-		"duftler",
 		"ethanfrogers",
 		"ezimanyi",
 		"jonsie",
-		"maggieneterval",
-		"plumpy",
+		"mneterval@google.com",
+		"plumpy@google.com",
 		"robzienert",
-		"ttomsu",
+		"ttomsu@google.com",
 	}
 
 	if !reflect.DeepEqual(got, want) {

--- a/users/ghteams/testing/teams.replay
+++ b/users/ghteams/testing/teams.replay
@@ -29,7 +29,7 @@
   },
   "Entries": [
     {
-      "ID": "ae2dae3291ba8f46",
+      "ID": "330a60cb2f933c83",
       "Request": {
         "Method": "GET",
         "URL": "https://api.github.com/orgs/spinnaker/teams/build-cops/members",
@@ -72,10 +72,10 @@
             "application/json; charset=utf-8"
           ],
           "Date": [
-            "Mon, 30 Mar 2020 15:41:04 GMT"
+            "Wed, 08 Apr 2020 18:52:30 GMT"
           ],
           "Etag": [
-            "W/\"6390efefc140dfa9f2720ec28ba12c5f\""
+            "W/\"1513409a3209681868848f6e479c7bc7\""
           ],
           "Referrer-Policy": [
             "origin-when-cross-origin, strict-origin-when-cross-origin"
@@ -106,7 +106,7 @@
             "github.v3; format=json"
           ],
           "X-Github-Request-Id": [
-            "8FDE:0850:A5894:22D3F3:5E82130F"
+            "9CA8:08C5:158AA0:24998B:5E8E1D6D"
           ],
           "X-Oauth-Scopes": [
             "read:org"
@@ -115,16 +115,934 @@
             "5000"
           ],
           "X-Ratelimit-Remaining": [
-            "4999"
+            "4939"
           ],
           "X-Ratelimit-Reset": [
-            "1585586464"
+            "1586374253"
           ],
           "X-Xss-Protection": [
             "1; mode=block"
           ]
         },
-        "Body": "H4sIAAAAAAAAA63aT2+jOBgG8O+Sw55GExv/ASpVo5XaQw80qpRZ7Wi0qmxjKFUSIkLSaap+9zXBOIEmRMacWkV+Hl7S/GQg/f0xWeRptprcTIqc7zO5kkU5+TbJ4skNBIGP4bfJKo/lc/XCJLp7ov/8+7gQr/dvszsBoqfbW7WY7VjJiudtsVBrXspyvbmZTusXN973NCtftny7kYXIV6Vcld9Fvpxup3X9j+2tBMRLAkol5iEnCUfUk4gkFMXCl4LAQPgCCxH+tbvF6mhpoY93GEm90DnuOtOHrI+jjruZts7tpVwuOsPWMx4CraVJvljkb6qhe3L9B5manBqv/j1bpYM6VO5jmpcvUr2/6lQ+qzcg25S2Ax0yH9Pqh/pTVi0b9ScrZGw5lE6pkd7UJ+XzY1rIdX6o2/KNKLJ1meUr2+FaWdWVFylbZXs2pEtlN6qiGst2jENGZeVOfUhtw3XoY7oush0T79VbUkghs516iwcVdtKqr3xfS/WJ/6k+BtUbnpXymcXLym7CFhv5+e1oWSSZ5IdlFRIEoBd65yFHb9H8gUTpVcjgIuS6XkH2uc98LkkAfA/HAiHpMSJDEQuKgcQBEUnoCcocIB9PrF/xcZ0VYR0b7rdd4IK3aXKS25SMx9Y0nnofYrYpsgXb5Oy1NslxqB7naCm3c7pebJfr94YpCT1KLjCFs/mD93h9v+1heqj/MXwTNcP20zPLrOTVqeHwWnkXd7rIiZ3uGE9dU+iKTvfYmtMxe3I6OI44M4UDOPaaF7FcVdv8YWcMAkou7Yx4dvcLuu2Mh3oHcifj9qM7WWjFrskNh9dpcKFnqpzwmZbx+B0rXQGaJluCJmiP0ETHYXgyiQNEuc+WbPWeaYgQhTAMLki838/m92R293DtZvPy5qf71UUqTHzOMfAJjzmhCYl9yjkXzJNEephIxCHkYeJyt3lybv1qTxZaqW1yw9V2GlzUmiontaZlPLXHSle1pslWrQnaqzXRcdSeTOKg9lXd3GdSm/UoomGIzl+wPnjR/heZzaPhZnW/w/Zpxu1naJZZIaxTwwm28i4AdZETP90xHr6m0JWe7rGFp2P27HRwHHRmCgdysnxhq6TIU/UUsrlqRR6GEJyHF+2j16c/0fzva/DQ5Qc6db/aLDkIIZYBwBKEjHIpGY9DmcQg5AlOhOfJUG2lvssTnc759UvtLLbyepodrvZMi4vdVp2T4FbTeI7bta6aW222plthe9mt+Di+OxM5KI+3SbkwD2wDjHwfBueBpyDaCxTN02vAL18N634FHAHGcEJBqIjHNAEBlIAHiAUMUkETRoi6JKYhcHhkezy1ftvHdVasdWy46HaBC+amyclxUzIeYdPoqrcpsoXb5OzNNslxuB7ncJBalvlyszW3rRBDQi5sxff7aP7053H+800t7/uSFF7ciiGqD1B9uwKwiDGUnKobV59SBBPJEQF+EHtKaYBBiHGccAeq5tz6pZplVlDr1HCnrbwLU13kpFR3jIe0KXQ1qntsieqYvVAdHAeomcLB55KlafVvDKUsdmzROCWh+q8CPzy/o96rL1ciL3oV5IrTyzsq1AdQTonnJySIEUeI8kB9+cljBAAPWez7gbqYFkQIdclMHZx+Ocd+r1+WW7ltp4f7Pdvj4rhT6OS50zWe626xq+9On63zTtzee6dgHPdfprL1/9//sUBtZ8gkAAA="
+        "Body": "H4sIAAAAAAAAA63ZUY+iOhgG4P/ixV5NFlpaoJNMNicZL+aCMZO4m7PZnExoKYpRMIi6o5n/foqUKoxiSrmaien78oE+KeKf42iZzZJ09DjKM3pIeMrzYvQwSqLRI7B9D4GHUZpF/L18YRQ8v7m//n1dssV4P3lmdvD29CQWh7uwCPP3bb4Ua+ZFsd48Wlb14gZ+nyXFfEu3G56zLC14Wnxn2craWlX9j+0TtzGMfdfliBKKY+q4kDs4dp2IeZxh4DOPIcbIt90TEkeb5fJ4p5HEC63jrhN5yOo44rgbq3Fu82K1bA1bzXgKNJbG2XKZ7UVD++S6D2KpnBiv+j9JZ706RO5oZcWci+srTuWzvADJptAd6JQ5WuUf8VaWLRvxluU80hxKpsRIe/FJ+TxaOV9np7ot3bA8WRdJluoO18iKriyfhWlyCPt0iexGVJRj6Y5xyogs34kPqW64Ch2tdZ7sQvZRXpKcM57sxCXuVdhKi77iY83FJ/6n+BiUFzwp+HsYrUq7cbjc8M+Hs2UWJ5yelpVIHBtAAq9DDvbB9AUHs7uQ7ZuQq3oB2aNe6FGOfduDKGKOw2GIOWERc5HNkY9ZTCBzQwPI5xPrVnxep0VYxvr7bRaY4K2bjOTWJcOxVY2X3vuYrYt0wdY5fa11chiq5zkayvWcrpfb1fqjZooJdPENpmAyfYGv9/fbDqan+h/9N1E1bDc9tUxLXpXqD6+RN3Eni4zYyY7h1NWFpuhkj645GdMnJ4PDiFNTGIALF1ke8bTc5k87o++7+NbOiCbPv4HZzniqNyB3MW43uouFWuzqXH94rQYTeqrKCJ9qGY7fudIUoGrSJaiC+ghVdBiGF5MYQOSHZBWmH4mECBwCiH9D4vgwmY7x5Pnl3pfN25uf7Bc3qSD2KEW2h2lEsRvjyHMppSyEHHOIMHcoAJTEJt82L86tW+3FQi21da6/2laDiVpVZaRWtQyn9lxpqlY16apVQX21KjqM2otJDNQuxJf7hEuz0HVcQpzrN6wvMDj8xpNp0N+s7DfYPtW43QzVMi2EVao/wUbeBKAsMuInO4bDVxea0pM9uvBkTJ+dDA6DTk1hQI4X8zCN82wmnkLWd60ORADY1+EFh2Dx9jeY/nMPnnP7gU7VLzZLahOAuG8jbpPQpZyHNCI8jmxCYxQzCDkRW6ln8kSndX7dUluLtbxeZvurvdJiYrdRZyS40TSc42atqeZGm67pRlhfdiM+jO/WRAbKiyJbbbbqZhgggPEN4ONDMH37+zr9uRfLu356ATeBA6c6QPnM1kYsQoBTV9wOe67rgJhTB9ueH0GMsI9sglAUU4Nnturcum2rZVqqq1R/z428iWRZZGRYdgynty40dSt7dMXKmL5VGRxGqZrCwOcqnM3KH0cLnu/CZe0UE/FbpUeub8Rj8cg2gMGC4TtOO761ygMIpxh6MfYjhzqOS33xkwqNHNumJIw8zxdbNMOMiY3YNXD65Ry7vX5ZruW2me7v92qPieNWoZHnVtdwrtvFpr5bfbrOW3F9762CYdx/mUrX/3//AzmdiFMeIQAA"
+      }
+    },
+    {
+      "ID": "58b21556604e8852",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/robzienert",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"9861829d8d5238a7c3946ffa0864ab87\""
+          ],
+          "Last-Modified": [
+            "Tue, 07 Apr 2020 16:23:01 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158AAF:2499A4:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4938"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374253"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA51U0W6bMBT9FeTnpBhG0xUpWqZ1D5vUTl27qcpLZMABr8ZGxpClKP++Y8jSJpMmkSfgcs65h+t76IjUuVAkJkYnL4IrbiyZEJGROKDvr6JgQpTO+MoVyO3N/ezn051Mf33efLtJ6e39fA4wa5llZtUYCUxhbVXHvj8Ua3qRC1s0SVNzk2plubIXqS79xh/kP7TzCBK52Yv0fVA4EavEXmcgQ6z2jwwXtpQnDobGPeEIutZS6g0UTh3/v4l/4MHecC9UfpYGeJ2vbcExNHzKzg1A1HasoZ7T+e6C83EqNc7B8GykqT0LljY4/l3nG17pXq5J6tSIygqtxpo74kJLm5wp8cLO0QK3hoSzNdZGzwGXt9i8seSB1PmVES1Lt24khqdctBjxWYInbOjZbcWx8T+wBm7gwvIVy0oXyDWTNUf6WOkA33XiLQ/xxE5XTG1RX9xxu5bitwd2gijvE4gAvu68iwBeS5320wfkgSnvq4a89+mjG07JhMsuKIt/aIUwnCUSJlQjJboIDegXb6PNs6eVd3CwqCuhFHvmxpmpmkSKdDXMPw6iy0OpX1sSR9d/Y4Qo4m/z+ox4kDikE5Kis8WsmUXHkNLrKb2ahrNHGsXRJRBL9Gmq7C0mpFMaAfYYzOLwXUyDJdn9AS61SFbkBAAA"
+      }
+    },
+    {
+      "ID": "e23966f484212bbc",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/cfieber",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"a98679cef8e3605ffaeb79fc723089f2\""
+          ],
+          "Last-Modified": [
+            "Wed, 18 Mar 2020 01:42:51 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158ABB:2499BA:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4937"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374253"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA5VTX2vbMBz8KkbPSfwnbdYYwjI6Bh2kMJaN0Zcgy4qtTZaELDvLQr97T1aabnkY+MmJdHe/8/l3JyJ1JRTJCdsLXnBLJkSUJJ8nabbMJkTpku/8Adl8/LL4/uNRsp+bw2b7cLupViuAaU8dtbvOSmBq50ybx3E4bOezSri6K7qWW6aV48rNmG7iLg7y7/vVDSQqexYZ5uDgSsyIs04gQ6yN39zWrpFX48PUAf2G22sp9QHca6//kY8vJLgKv4WqxguAdIq1qzmCgv1n/9KidaOsDIRT7B/4IF6iRfCWl2PsnCkwc1DwcYotN3rQ6oqWWWGc0GqUrX+IENK2okr8oaOFQGzB94ZGGRgIIPIe6zWKGRin2FjRU3b0MVjOuOiR6Xi1KyrE3NFwLPQ3fHGfsHB8R8vGl21PZctRLtp4wD0eVqvo02sBsbiGqiOu1o/c7aX4HUGgQFNDP6RmQ77495Wq6LOGWHT/wYfQUOGLyILkOnR6xijuamE5LSQmqk5K6AkN5ENU6ihat0YoRX9xG7ka2+oDNV0hBduFfPPFu8vJsIkkT18rgU6RfIn7S0NIfjchDOMcoqQOY7IkTabJYpost1ma32R5kj1hRmfKvzEZMPNperdNBsxt+kSeXwBYC4BRogQAAA=="
+      }
+    },
+    {
+      "ID": "f6b9951c01624d9c",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/plumpy",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"19189a53e040a70e436216f29f17d586\""
+          ],
+          "Last-Modified": [
+            "Wed, 08 Apr 2020 18:16:20 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158AD1:2499D8:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4936"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374252"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA5VTy27bMBD8FYNnJ9TDNlwCRgKklx7sNoBbNLkYlMRIbCmSoCgFrpB/71BSjNRADzqJWs7Mjka7PVGmlJowYlVb2zNZElkQlq4/JZv1kmhTiFMokP3nx82PnweV/9rHX49fksPjbgcw77jn7tQ6BUzlvW0YpWOxiW5L6as2axvhcqO90P42NzVt6Sh/1+1WkCjdJDL0QeFKzMpJZyRDrKEXs5Wv1VX3sekAvsBejFLmFcxrp/8XpxcOLI1nqcvZfHB6anwlEBKsv4UPlo2fY2TA9zQ88C+CQoPMnShmmJkYsPKq4aKnTlgzSLVZkztpvTR6jql/eNAxruRa/uFzdcBrQA925rQf8OCJDlM1hzgSemqd7Hh+DhE4kQvZIc7ZYldMaPmzFZji7/jVIVzpxYkXdViwF64agY3idQDsZV5xoRbfwtYBiWm1XJ9xc18aUyqxuG+s1Jr/Fm6B+wxrOm6HMvkQMt4OTw8hgprLsH3jsE/0MP64q6QTPFPoqFulICPN+9G2mZL5aQySpemSTJVh3AiL3qceW0PY6sMODHc5hD0y4x6tkyiObqLtTRwdo5ilW7ZOn9G9tcVHTALMCrBjvGXxhiXRM3n7C1DmHyeABAAA"
+      }
+    },
+    {
+      "ID": "21543c97e47e45cc",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/ajordens",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"9b9b8a6a6c46712d6fa27ea1a8f4b387\""
+          ],
+          "Last-Modified": [
+            "Wed, 01 Apr 2020 19:37:43 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158AD9:2499E9:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4935"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374252"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA51U0W7aMBT9lch7BRIgZW0ktE5lL5PoNLWbtr4gJzHhFseOHBvGUP+9x0nGGA+T0qdE9jnnntx7T45M6oIUSxh/1iYXqmYDRjlLptfXs6vJgCmdi5U/YMvF19n3H/cye17GXxY/x8tiPgeY77jlZuWMBGZjbVUnYdge1tGoILtxqauFybSyQtlRpsvQha38h908hkRhOpGmDg4uxCrqdFoyxOrwzO7GlvKiflu2gZ8B11pKvQf70u3/CoQnFoy176SKNyiAdQy13Qg0C5/w4j+catvPTMM4hv6BqXiNGt03Iu9lqOPAzl7ByTE0otKNmEvrzFBlSat+xv5hQkmbgiv6zfsrgemX0FvqZ6FhgCl22LN+1JZyDCtDO54dfCuMyATt0Ng3yF1woWYPlcBuf8PgfZvJihXPSx+8NZe1QM546QEfc14Gn09JxAJXXB1wcS/sWtIvkFMktosakpbxkSS1FTmpZt1JhRwaf8MsddYMAZQ7LmmtjSLuu1RyQmSVk3LANmQETyUcWOPgJiUN/INe2z03Ivik8I8QwgS3nY1gr80WCx1oFdw+VKQU3+L63R1CTsppVy+ERPfMYYRSlUslZat2Pkk8Pp0028ySyZ9gIZosieOznLFkNmAZzFlMgluYmkTjaBjdDKOrx0mUTG+SafSEGq7KzzETYOJhNH4cA/A+iadP7OUVEEWEI+wEAAA="
+      }
+    },
+    {
+      "ID": "001625a1a010a195",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/ezimanyi",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"0620cc0063c6451ed7cc202ba9828ddb\""
+          ],
+          "Last-Modified": [
+            "Tue, 07 Apr 2020 21:15:03 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158AE6:2499FA:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4934"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374252"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA51UO2/bMBj8KwZnO9TDdhMBQTvEQ4c6KOAWjReDohiJCUUKFCXDFvLfe5SUwPVQQJnEx3fH4/E7dUSZXGqSEHGWJdMnSeZEZiQJ47vw7jaaE20ycfAr5MfDz/XvP1vFXzbnx91m9fjw/R7VrGWO2UNjFWoK56o6oXRYrOObXLqiSZtaWG60E9rdcFPSho78X9v7JThyO7L0B2Hhiq2SI9GABltNLwQXrlRXAoZz+/KLwmejlDkCfS33fwfQDxSEDWOp808wANVR4woBt3CFN39xWbtpYnpER/0Hz+I5athvRTZJ0IiBnKOGko5aUZmerElrbmXlpNHThP2DBJOxOdPyzKYzAVmDwEuaJqFHAClaNNo06ADpaGVly/jJW2EFF7KFsZ+gu8KCzZ0qgd7+hYf3NksnDiwrffSemaoFgsZKX7Cxks/2H1lEA1eIJTa+5cbkSsyAThHaISfK8N5gzLbiOHsy9nU+2z55D0omkUjdKDUnhbSCpQr8wzyV5n1YNamS/DBYlyzDORlX+kbDj+C955EakkTriwj0mxzMDiYxBw1REEaLIFzEwS5cJ6vbJF7uoaWpssuaKFgEy0XwZReFSbhKgnhP3v4CGQqACokEAAA="
+      }
+    },
+    {
+      "ID": "0e62646496d96b30",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/jonsie",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"d659c446971b14c152a5e382d23c2523\""
+          ],
+          "Last-Modified": [
+            "Mon, 23 Mar 2020 16:49:40 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158AF3:249A0D:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4933"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374252"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA5VU0W6bMBT9lcjPSSDAogapaqfuZZPSaWo2bX2JDDjgztiWbWBp1H/fMbAsitQHJCTgcs65h8O9nIhQJZckJS9KWs7InPCCpNE6Xm828ZxIVbC9r5Dtp2/rHz8fRf7yOdq+/vrwdbe9BZq21FGzb4wApnJO2zQIhqINlyV3VZM1lplcScekW+aqDppg1L9rbxNolGZU6RuhcKWm+Sg0sKFmg7PdytXiqv3QtQefYQclhOrAvLb6vnhw5sDScM1lOZkPzilQrmJICdbf/Atz66YY6fGnwJ/wMbyCReiGFRPMjAxY6SRcnALDtOqlmszmhmvHMQFTBC950FGmpJK/0qk64FnQvZ0p7Xs8eKzFWE0hDoRToA1vaX70ERiWM94izsliV0xouaNmmOLv+NQ+XO7Ynha1X7EDFZZhpWjtAQ+V4Xb2VFMh2BFITKum8ognj8wdBP+DWoblHNcKW9V13TL3LDuQ/IADJFTeZw7gE5WzLwpNZg8ffTQ15VhL2QgxJxU3jGYCrYf7jCsw7q3mUtLfzMzu//fVTSZ4vh8iTm9u5mSs9IOI38O/fcA+kXSVXKwHbvHbyNHLIU/q0CMKV9FiFS6iZBdGKY44eYa7RheXmChchPEiinerdZps0iR8Jm9/ATQQ4DKeBAAA"
+      }
+    },
+    {
+      "ID": "8b2c370f36f8b842",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/ethanfrogers",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"6e85605970fb15b58e91a45d7ed06494\""
+          ],
+          "Last-Modified": [
+            "Tue, 10 Mar 2020 18:13:01 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158AFC:249A20:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4932"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374252"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA51UwW6cMBT8FeLzbmwgrSKrUVO1OfSwkdJuqyqX1QO84NTYljFsySr/nmeg25ZLxZ7A5s28YfzGR6JMKTXhRPgK9N6ZUriGrIgsCE/T5CqO2YpoU4hd2CGbTw9vv/+4V/nT5nnz9PBrs/1wg9XQgQe3a53Cmsp723BKx82GXZbSV23WNsLlRnuh/WVuatrSif99d3OFHKWbWIZGuDFjs3IiGtHI1tCZ6MrXaiZi7D1AZsV7o5Q5IMtc9v8a0RMSRY7vUpdnsiDySI2vBLqHv/QSjJCNXy5qQB1peOBRBZ4Gj8SJYrGwCYeyDhoVHakT1gyEbdbkTlovjV4u8B80shlXgpbPcB4bosOYBmnLpQwoRIsOh3E5fIQdqXWyg7wP1jiRC9mh2WdSzvDI6HsrMAffcCiC9dKLHRR1iOoeVCMwlFCHgruQ2+jL79zioFvQPX64BVcb10eIzjDkY6aUyQfDcfWxAu9BG1PCKtreBztqkBhg3Sq1IpV0AjKFLcZ1Jk0AmbputfR99NXs/QGciO40XiBCuGhqeBF9jt6l0W1jpdbwU7gLpLZtpmS+G43n1+lpZxhbwsMt8ydWPD0tMR+E4ypHNR79BY8qEhanaxavk3jLGH+T8oQ9YpPWFn/XJGzN0nXMtvE1j1PO4kfy8gojNu1r8AQAAA=="
+      }
+    },
+    {
+      "ID": "e74696a1777a54c7",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/ttomsu",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"af498b6e523933b93dbf1c7b1437ece3\""
+          ],
+          "Last-Modified": [
+            "Wed, 08 Apr 2020 17:08:38 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158B0C:249A34:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4931"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374252"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA5VTTW+cMBT8Kyuf2fARSLaWqvbQHrNSJFI1uawMOODW2Mg2bDco/71jYFfpSj1wwthv5o3H80YidS0UocQ53dqeBERUhMa3cRpnWRQQpSt+8Fvk4dvj3Y+fe1n++v72kD/+2edPR5SzgTlmDr2RqGmc6ywNw3nTJje1cE1f9JabUivHlbspdRv24bnBl+FzCpLaLDRTJ2xc0XViYZrhoLPhRXDjWnnVf247FV/KXrWU+gjktdb/k4cXDCTNa6Hq1XhgxlC7hsMmSH/3FxbWrREy1Y+h/+A1PIOF64ZXK8QsCEg5KqgYQ8M7PVH1hS2N6JzQao2of3Dg0aZmSryxtTzAWcC9nDXtp3rg+IBcrQHOgDHsjBhYefIWGF5yMcDO1WRXSHC5U8eR4ic8tTdXOH5gVeuH7JVJyzFTrPUFOUIv7CZf5g5h7Zg64eBrrXUtOcAFpnMeCKnLyVf87flx86zN72Czf/bXb5nwszcHfcH66OOsEYazAlRU9VKCT+jzsusLKcrDbCLN7gKy7ExRIzQ9Jx4TQ+juQ/4JzQJSgtjBL+bQOonibBvdb6M4T2KafKJZ+oLufVd9rEmibZRuo10e39NoR293L+T9L5reyxqABAAA"
+      }
+    },
+    {
+      "ID": "17626c8c6a4c188e",
+      "Request": {
+        "Method": "GET",
+        "URL": "https://api.github.com/users/maggieneterval",
+        "Header": {
+          "Accept": [
+            "application/vnd.github.v3+json"
+          ],
+          "Accept-Encoding": [
+            "gzip"
+          ],
+          "User-Agent": [
+            "go-github"
+          ]
+        },
+        "MediaType": "",
+        "BodyParts": null
+      },
+      "Response": {
+        "StatusCode": 200,
+        "Proto": "HTTP/1.1",
+        "ProtoMajor": 1,
+        "ProtoMinor": 1,
+        "Header": {
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Access-Control-Expose-Headers": [
+            "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset"
+          ],
+          "Cache-Control": [
+            "private, max-age=60, s-maxage=60"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Security-Policy": [
+            "default-src 'none'"
+          ],
+          "Content-Type": [
+            "application/json; charset=utf-8"
+          ],
+          "Date": [
+            "Wed, 08 Apr 2020 18:52:30 GMT"
+          ],
+          "Etag": [
+            "W/\"879be67e6160610b7a2c6aff17e37837\""
+          ],
+          "Last-Modified": [
+            "Wed, 08 Apr 2020 17:27:41 GMT"
+          ],
+          "Referrer-Policy": [
+            "origin-when-cross-origin, strict-origin-when-cross-origin"
+          ],
+          "Server": [
+            "GitHub.com"
+          ],
+          "Status": [
+            "200 OK"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000; includeSubdomains; preload"
+          ],
+          "Vary": [
+            "Accept, Authorization, Cookie, X-GitHub-OTP",
+            "Accept-Encoding, Accept, X-Requested-With"
+          ],
+          "X-Accepted-Oauth-Scopes": [
+            ""
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "deny"
+          ],
+          "X-Github-Media-Type": [
+            "github.v3; format=json"
+          ],
+          "X-Github-Request-Id": [
+            "9CA8:08C5:158B18:249A4E:5E8E1D6E"
+          ],
+          "X-Oauth-Scopes": [
+            "read:org"
+          ],
+          "X-Ratelimit-Limit": [
+            "5000"
+          ],
+          "X-Ratelimit-Remaining": [
+            "4930"
+          ],
+          "X-Ratelimit-Reset": [
+            "1586374252"
+          ],
+          "X-Xss-Protection": [
+            "1; mode=block"
+          ]
+        },
+        "Body": "H4sIAAAAAAAAA52UX2+bMBTFv0rk56QGmj+Npal92B6TaVI2rX2JjHHBnbGRMUQZ6nffMZCuSx8m8RQw9/zuybWPO6JtrgxhpOR5rqSRXrqWazInKiMsXm1v18lmOyfGZvIYlsju87f1j597LV6+xF8Pu2T3IlYo5y333B0bp1FTeF/VjNJhsY5vcuWLJm1q6YQ1Xhp/I2xJG3ppcN9+WgKSuxHTd8LCFa5SI2mQA1fTD8YLX+orH0P7XvSh/NlqbU8gXXv/fzP6poXV4VmZfDIH2o5aX0iMEX/tNQxE1X6KsV7X0fCDXQukGrvjZDbB3KiEtZOBq446Wdke2aS1cKryypopJv/Rg2ddzo36zafyoK+BCfam2Ol10MsW53MKYBB2tHKq5eIcRuSkkKrF2CdDrwhg+nMlkY7vOCJhE5SXR56VIcTPXNcSWeVlKNj1iZ7t/0Ya57/i5oxvD7m1uZbQp7gAhqxpK/rR420vT7NH637NZ/vHMJGSqxDr8nI9jPIQKHwulJM8BY2ZRmsglb08Vk2qlTgOo2XrzZyMK/0BJSy65Ab5w3WzfBcjwvAmQPYYH/don0TxahHHiyQ6RLcsvmPx9gntmyp7X5NEi2i5iO4O8YYlG7aMn8jrHzuYxlbnBAAA"
       }
     }
   ]


### PR DESCRIPTION
This change will allow build cops (who opt-in to making their work email address public) to be invited to their rotation shift (and thus have it automatically added to their calendar).

Several people have personal email addresses listed, and we likely don't want to use those, so there is a suffix filter in there to make sure some known domains can be used.

cc @spinnaker/build-cops - Change your public email in your profile: https://github.com/settings/profile